### PR TITLE
readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone https://github.com/Fannovel16/comfy_controlnet_preprocessors
 cd comfy_controlnet_preprocessors
 ```
 Next, run install.py. It will download all models by default. <br>
-Add `--no-download-ckpts` to not download any model. <br>
+Add `--no_download_ckpts` to not download any model. <br>
 When a preprocessor node runs, if it can't find the models it need, that models will be downloaded automatically. 
 For directly-cloned ComfyUI repo:
 ```


### PR DESCRIPTION
`--no-download-ckpts` was giving back a `install.py: error: unrecognized arguments: --no-download-ckpts`.

Fixed changing to `--no_download_ckpts`