### PR TITLE
Fix module import issue in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -7,6 +7,7 @@ import subprocess
 
 this_module_name = "comfy_controlnet_preprocessors"
 EXT_PATH = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.abspath(os.path.join(EXT_PATH, "../../")))
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--no_download_ckpts', action="store_true", help="Don't download any model")


### PR DESCRIPTION
This PR addresses an issue I encountered in `install.py` while trying to install the package on a Linux system. The `comfy` module could not be found, leading to a `ModuleNotFoundError` when running the script.

The issue was caused by the `comfy` directory not being included in the Python module search path (`sys.path`). This problem might not manifest itself on every system, but it occurred on my Linux system and could potentially affect other users as well. The code might have been developed on a Windows system, where the issue did not appear due to differences in the module search path.

To fix this and ensure the script works correctly on different environments, including both Windows and Linux systems, I added the parent directory of `comfy` to `sys.path` in `install.py`.

Here are the changes I made in `install.py`:

```python
import os
from time import sleep
from importlib.util import spec_from_file_location, module_from_spec
import sys
import argparse
import subprocess

this_module_name = "comfy_controlnet_preprocessors"
EXT_PATH = os.path.dirname(os.path.realpath(__file__))
sys.path.append(os.path.abspath(os.path.join(EXT_PATH, "../../")))

# ... other code ...