### PR TITLE
Remove unused parameter in __init__.py

### DIFF
--- a/v1/leres/__init__.py
+++ b/v1/leres/__init__.py
@@ -51,7 +51,7 @@ def apply_leres(input_image, thr_a, thr_b):
     if model is None:
         model_path = download_model_if_not_existed()
         checkpoint = torch.load(model_path, map_location='cpu')
-        model = RelDepthModel(backbone='resnext101', map_location='cpu')
+        model = RelDepthModel(backbone='resnext101')
         model.load_state_dict(strip_prefix_if_present(checkpoint['depth_model'], "module."), strict=True)
         model.to(model_management.get_torch_device())
         del checkpoint


### PR DESCRIPTION
It looks `LeReS-DepthMapPreprocessor` is not working because of extra parameter.
I got following error.

```python
TypeError: __init__() got an unexpected keyword argument 'map_location'
```

So, I removed a parameter.