### PR TITLE
Compatibility with linux, paths and bugfixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,3 @@
 # where are the ckpts stored?
-annotator_ckpts_path: "R:\\controlnet_pre_ckpts\\ckpts"
 skip_v1: True
-#annotator_ckpts_path: "./ckpts"
+annotator_ckpts_path: "./ckpts"

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ if [ -e "../../../python_embeded/python" ]; then
     ../../../python_embeded/python install.py ${1:+"$1"} #One-liner is za bezt
 else
     echo "Custom Python not found. Use system's Python executable instead:"
-    echo "$(which python)"
+    echo "$(which python3)"
     echo --------------------------------------------------
-    python.exe install.py ${1:+"$1"}
+    python3 install.py ${1:+"$1"}
 fi

--- a/v1/midas/__init__.py
+++ b/v1/midas/__init__.py
@@ -4,7 +4,7 @@ import torch
 
 from einops import rearrange
 from .api import MiDaSInference
-import comfy.model_management
+import comfy.model_management as model_management
 
 
 class MidasDetector:


### PR DESCRIPTION
Changed the default path to match documentation and a sensible generic choice.
Fixed import in one of the model init.
Fixed the linux install script.