### PR TITLE
fix: deps(ftfy, mediapipe), cross platform support, import error, `Zoe-DepthMapPreprocessor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Example images: WIP
 | ColorPreprocessor           | color                                                 | t2iadapter_color                          | preprocessors/color_style        |
 |MediaPipe-FaceMeshPreprocessor| mediapipe_face                                       | controlnet_sd21_laion_face_v2             | preprocessors/face_mesh          |
 
-
 ## Install
 Firstly, [install comfyui's dependencies](https://github.com/comfyanonymous/ComfyUI#installing) if you didn't.
 Then run:
@@ -153,7 +152,7 @@ Add `--no_download_ckpts` to the command in below methods if you don't want to d
 When a preprocessor node runs, if it can't find the models it need, that models will be downloaded automatically.
 ### New dependencies installation method
 Open the terminal then run
-```
+```sh
 install
 ```
 It will automatically find out what Python's build should be used and use it to run install.py
@@ -167,6 +166,16 @@ python install.py
 For ComfyUI portable standalone build:
 ```
 /path/to/ComfyUI/python_embeded/python.exe install.py
+```
+
+## Apple Silicon
+A few preprocessors utilize operators not implemented for Apple Silicon MPS device, yet.
+For example, `Zoe-DepthMapPreprocessor` depends on `aten::upsample_bicubic2d.out` operator.
+Thus you should enable `$PYTORCH_ENABLE_MPS_FALLBACK`.
+This makes sure unimplemented operators are calculated by the CPU.
+
+```sh 
+PYTORCH_ENABLE_MPS_FALLBACK=1 python /path/to/ComfyUI/main.py
 ```
 
 ## Model Dependencies 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ scikit-image
 prettytable==3.6.0
 addict
 yapf
-mediapipe==0.9.1.0
+mediapipe
 fvcore
 omegaconf
+ftfy

--- a/v1/midas/__init__.py
+++ b/v1/midas/__init__.py
@@ -6,16 +6,15 @@ from einops import rearrange
 from .api import MiDaSInference
 import comfy.model_management
 
-
 class MidasDetector:
     def __init__(self):
-        self.model = MiDaSInference(model_type="dpt_hybrid").to(model_management.get_torch_device())
+        self.model = MiDaSInference(model_type="dpt_hybrid").to(comfy.model_management.get_torch_device())
 
     def __call__(self, input_image, a=np.pi * 2.0, bg_th=0.1):
         assert input_image.ndim == 3
         image_depth = input_image
         with torch.no_grad():
-            image_depth = torch.from_numpy(image_depth).float().to(model_management.get_torch_device())
+            image_depth = torch.from_numpy(image_depth).float().to(comfy.model_management.get_torch_device())
             image_depth = image_depth / 127.5 - 1.0
             image_depth = rearrange(image_depth, 'h w c -> 1 c h w')
             depth = self.model(image_depth)[0]

--- a/v1/uniformer/mmseg/apis/inference.py
+++ b/v1/uniformer/mmseg/apis/inference.py
@@ -8,7 +8,7 @@ from custom_nodes.comfy_controlnet_preprocessors.v1.uniformer.mmseg.datasets.pip
 from custom_nodes.comfy_controlnet_preprocessors.v1.uniformer.mmseg.models import build_segmentor
 
 
-def init_segmentor(config, checkpoint=None, device='cuda:0'):
+def init_segmentor(config, checkpoint=None):
     """Initialize a segmentor from config file.
 
     Args:
@@ -34,7 +34,6 @@ def init_segmentor(config, checkpoint=None, device='cuda:0'):
         model.CLASSES = checkpoint['meta']['CLASSES']
         model.PALETTE = checkpoint['meta']['PALETTE']
     model.cfg = config  # save the config in the model for convenience
-    model.to(device)
     model.eval()
     return model
 

--- a/v11/hed_v11/__init__.py
+++ b/v11/hed_v11/__init__.py
@@ -62,7 +62,7 @@ class HEDdetector:
             from custom_nodes.comfy_controlnet_preprocessors.util import load_file_from_url
             load_file_from_url(remote_model_path, model_dir=annotator_ckpts_path)
         self.netNetwork = ControlNetHED_Apache2().float().to(model_management.get_torch_device()).eval()
-        self.netNetwork.load_state_dict(torch.load(modelpath))
+        self.netNetwork.load_state_dict(torch.load(modelpath, map_location=model_management.get_torch_device()))
 
     def __call__(self, input_image, safe=False):
         assert input_image.ndim == 3

--- a/v11/lineart/__init__.py
+++ b/v11/lineart/__init__.py
@@ -11,7 +11,6 @@ from einops import rearrange
 from custom_nodes.comfy_controlnet_preprocessors.util import annotator_ckpts_path
 import comfy.model_management as model_management
 
-
 norm_layer = nn.InstanceNorm2d
 
 
@@ -104,7 +103,7 @@ class LineartDetector:
             from custom_nodes.comfy_controlnet_preprocessors.util import load_file_from_url
             load_file_from_url(remote_model_path, model_dir=annotator_ckpts_path)
         model = Generator(3, 1, 3)
-        model.load_state_dict(torch.load(modelpath, map_location=torch.device('cpu')))
+        model.load_state_dict(torch.load(modelpath, map_location=model_management.get_torch_device()))
         model.eval()
         model = model.to(model_management.get_torch_device())
         return model

--- a/v11/lineart_anime/__init__.py
+++ b/v11/lineart_anime/__init__.py
@@ -122,7 +122,7 @@ class LineartAnimeDetector:
             load_file_from_url(remote_model_path, model_dir=annotator_ckpts_path)
         norm_layer = functools.partial(nn.InstanceNorm2d, affine=False, track_running_stats=False)
         net = UnetGenerator(3, 1, 8, 64, norm_layer=norm_layer, use_dropout=False)
-        ckpt = torch.load(modelpath)
+        ckpt = torch.load(modelpath, map_location=model_management.get_torch_device())
         for key in list(ckpt.keys()):
             if 'module.' in key:
                 ckpt[key.replace('module.', '')] = ckpt[key]

--- a/v11/pidinet_v11/__init__.py
+++ b/v11/pidinet_v11/__init__.py
@@ -4,10 +4,10 @@
 import os
 import torch
 import numpy as np
+import comfy.model_management
 from einops import rearrange
 from .model import pidinet
 from custom_nodes.comfy_controlnet_preprocessors.util import annotator_ckpts_path, safe_step, load_file_from_url
-
 
 class PidiNetDetector:
     def __init__(self):
@@ -16,15 +16,16 @@ class PidiNetDetector:
         if not os.path.exists(modelpath):
             load_file_from_url(remote_model_path, model_dir=annotator_ckpts_path)
         self.netNetwork = pidinet()
-        self.netNetwork.load_state_dict({k.replace('module.', ''): v for k, v in torch.load(modelpath)['state_dict'].items()})
-        self.netNetwork = self.netNetwork.cuda()
+        self.netNetwork.load_state_dict({k.replace('module.', ''): v for k, v in torch.load(
+            modelpath, map_location=comfy.model_management.get_torch_device())['state_dict'].items()})
         self.netNetwork.eval()
+        self.netNetwork = self.netNetwork.to(comfy.model_management.get_torch_device())
 
     def __call__(self, input_image, safe=False):
         assert input_image.ndim == 3
         input_image = input_image[:, :, ::-1].copy()
         with torch.no_grad():
-            image_pidi = torch.from_numpy(input_image).float().cuda()
+            image_pidi = torch.from_numpy(input_image).float().to(comfy.model_management.get_torch_device())
             image_pidi = image_pidi / 255.0
             image_pidi = rearrange(image_pidi, 'h w c -> 1 c h w')
             edge = self.netNetwork(image_pidi)[-1]

--- a/v11/zoe/zoedepth/models/base_models/midas.py
+++ b/v11/zoe/zoedepth/models/base_models/midas.py
@@ -171,7 +171,7 @@ class Resize(object):
 
     def __call__(self, x):
         width, height = self.get_size(*x.shape[-2:][::-1])
-        return nn.functional.interpolate(x, (height, width), mode='bilinear', align_corners=True)
+        return nn.functional.interpolate(x, (height.item(), width.item()), mode='bilinear', align_corners=True)
 
 class PrepForMidas(object):
     def __init__(self, resize_mode="minimal", keep_aspect_ratio=True, img_size=384, do_resize=True):

--- a/v11/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/beit.py
+++ b/v11/zoe/zoedepth/models/base_models/midas_repo/midas/backbones/beit.py
@@ -44,7 +44,7 @@ def _get_rel_pos_bias(self, window_size):
     old_sub_table = old_relative_position_bias_table[:old_num_relative_distance - 3]
 
     old_sub_table = old_sub_table.reshape(1, old_width, old_height, -1).permute(0, 3, 1, 2)
-    new_sub_table = F.interpolate(old_sub_table, size=(new_height, new_width), mode="bilinear")
+    new_sub_table = F.interpolate(old_sub_table, size=(new_height.item(), new_width.item()), mode="bilinear")
     new_sub_table = new_sub_table.permute(0, 2, 3, 1).reshape(new_num_relative_distance - 3, -1)
 
     new_relative_position_bias_table = torch.cat(


### PR DESCRIPTION
- Fixed dependency installations issues ([`61d0d1c`](https://github.com/Fannovel16/comfy_controlnet_preprocessors/pull/63/commits/61d0d1c2a7d53a763d613815baf8585909b74c2c)): Closing #49 and #56.

- Fixed import error ([`23850b9`](https://github.com/Fannovel16/comfy_controlnet_preprocessors/pull/63/commits/23850b961513893e8941681acc1b52c9346916b4)): Closing #60

- Support non-cuda platform (e.g. Apple Silicon `'mps'`) ([`52accd0`](https://github.com/Fannovel16/comfy_controlnet_preprocessors/pull/63/commits/52accd0cc00bcd44ec0f64f6258b902e8db9e2e3)): Closing #51

- Fixed numpy and pytorch API type mis-cast ([`8e56f5f`](https://github.com/Fannovel16/comfy_controlnet_preprocessors/pull/63/commits/8e56f5fd766f734e59bbad803a66788663bde116)): Closing #66

- Guided `$PYTORCH_ENABLE_MPS_FALLBACK` on README for Apple Silicon ([`8e56f5f`](https://github.com/Fannovel16/comfy_controlnet_preprocessors/pull/63/commits/8e56f5fd766f734e59bbad803a66788663bde116)) Related to #51

I verified it working on my machine.

**Info**:

- OS: macOS Ventura 13.4.1 (22F82)
- HW: Apple M1 Max
- python: 3.10.10
- pip: 23.0.1
- env: a miniconda environment dedicated to only ComfyUI
