### PR TITLE
fix: incorrect call to imported module

### DIFF
--- a/v1/midas/__init__.py
+++ b/v1/midas/__init__.py
@@ -8,13 +8,13 @@ import comfy.model_management as model_management
 
 class MidasDetector:
     def __init__(self):
-        self.model = MiDaSInference(model_type="dpt_hybrid").to(comfy.model_management.get_torch_device())
+        self.model = MiDaSInference(model_type="dpt_hybrid").to(model_management.get_torch_device())
 
     def __call__(self, input_image, a=np.pi * 2.0, bg_th=0.1):
         assert input_image.ndim == 3
         image_depth = input_image
         with torch.no_grad():
-            image_depth = torch.from_numpy(image_depth).float().to(comfy.model_management.get_torch_device())
+            image_depth = torch.from_numpy(image_depth).float().to(model_management.get_torch_device())
             image_depth = image_depth / 127.5 - 1.0
             image_depth = rearrange(image_depth, 'h w c -> 1 c h w')
             depth = self.model(image_depth)[0]


### PR DESCRIPTION
`comfy.model_management` was imported as `model_management`, but in the code it still was called as `comfy.model_management`. This fixed my installation issue: 
`NameError: name 'comfy' is not defined`