### PR TITLE
fix: deprecated Image.LINEAR is removed since Pillow 10.0.0

### DIFF
--- a/v11/oneformer/detectron2/data/transforms/transform.py
+++ b/v11/oneformer/detectron2/data/transforms/transform.py
@@ -43,7 +43,7 @@ class ExtentTransform(Transform):
     See: https://pillow.readthedocs.io/en/latest/PIL.html#PIL.ImageTransform.ExtentTransform
     """
 
-    def __init__(self, src_rect, output_size, interp=Image.LINEAR, fill=0):
+    def __init__(self, src_rect, output_size, interp=Image.BILINEAR, fill=0):
         """
         Args:
             src_rect (x0, y0, x1, y1): src coordinates


### PR DESCRIPTION
This patch fixes this issue.

https://github.com/Fannovel16/comfy_controlnet_preprocessors/issues/78